### PR TITLE
Timeout in request

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,10 @@ On Mac `python3 -m pip install -r requirements.txt`
 
 1.  Run the script and enter the prezi url. `python3 prezi2pdf.py -u "YOUR_PREZI_URL"`  
 2. The script will start downloading en converting it into a pdf file.
+
+Note that the `YOUR_PREZI_URL` is a little ambigous. You should find the link that contains an ID of the following form: 12 symbols long, each either a digit, a lowercase letter, or a hyphen. 
+Example: 
+```
+https://prezi.com/p/edit/vk713bm8qr-k/
+```
+In the case above, to get this link I have to open the presentation in the "Edit" mode.

--- a/prezi2pdf.py
+++ b/prezi2pdf.py
@@ -36,7 +36,8 @@ def download_video(id):
 
 def download_presentation(id):
     url = f"https://prezi.com/api/v2/storyboard/{id}/"
-    data = requests.get(url).json()
+    print("Requesting data from API, please wait up to 60 seconds...")
+    data = requests.get(url, timeout=60).json()
     try:
         os.mkdir(f"./presentations")
     except FileExistsError:


### PR DESCRIPTION
I have added a timeout of 60 seconds in the requests.get (line 39 @ prezi2pdf.py).
Without it, the code returned empty `data` with status=Wait.

I have also made README.md a bit more informative.
