### PR TITLE
support public Prezi links and PPTX support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,4 @@ https://prezi.com/p/edit/vk713bm8qr-k/
 ```
 In the case above, to get this link I have to open the presentation in the "Edit" mode.
 If you only have the public viewing link (`https://prezi.com/p/<ID>/…`), the script picks up the 12-character ID automatically and you can still download the slides.
+By default the download gets converted to PDF, but you can pass `-t pptx` if you prefer a PowerPoint output; the same `presentations/` folder will accumulate the `.pptx` file.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,4 @@ Example:
 https://prezi.com/p/edit/vk713bm8qr-k/
 ```
 In the case above, to get this link I have to open the presentation in the "Edit" mode.
+If you only have the public viewing link (`https://prezi.com/p/<ID>/…`), the script picks up the 12-character ID automatically and you can still download the slides.

--- a/prezi2pdf.py
+++ b/prezi2pdf.py
@@ -90,7 +90,7 @@ def download_presentation(id):
         with open(f"./presentations/{id}.json", 'w') as outfile:
             outfile.writelines(json.dumps(data, indent=4))
 
-match = re.search(r"/p/(?:edit/)?([0-9a-zA-Z-]{12})", args.url)
+match = re.search(r"prezi\.com/(?:p/(?:edit/)?)?([0-9a-zA-Z-]{12})", args.url)
 if not match:
     print("Please provide a valid Prezi URL that contains the 12-character presentation ID.")
     sys.exit(1)

--- a/prezi2pdf.py
+++ b/prezi2pdf.py
@@ -1,5 +1,6 @@
 import requests
 import re, os, json
+import sys
 from img2pdf import convert
 import yt_dlp
 import argparse
@@ -56,7 +57,12 @@ def download_presentation(id):
         with open(f"./presentations/{id}.json", 'w') as outfile:
             outfile.writelines(json.dumps(data, indent=4))
 
-id = re.findall('([0-z|-]{12})', args.url)[0]
+match = re.search(r"/p/(?:edit/)?([0-9a-zA-Z-]{12})", args.url)
+if not match:
+    print("Please provide a valid Prezi URL that contains the 12-character presentation ID.")
+    sys.exit(1)
+
+id = match.group(1)
 
 if "prezi.com/v/" in args.url:
     download_video(id)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 img2pdf==0.4.4
 requests==2.27.1
 yt_dlp==2022.8.14
+Pillow==10.2.0


### PR DESCRIPTION
Script now extracts the 12-character presentation ID from both /p/<ID>/… and /p/edit/<ID>/… URLs, exits cleanly when the ID is missing, and the README explains the supported public-view link with an explicit example command, and PPTX support as output.
By the way, the tool is really useful! Thanks!
